### PR TITLE
Move the kafka topics into the role. The kafka replicas and number

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,16 @@ The monasca services for mysql, influxdb and kafka must be up and running.
 - influxdb_url - URL of the influxdb server
 - mysql_users - dictionary of user/password pairs
 
-Optionally for defining topics, define kafka_topics for example
-    kafka_topics:
-      metrics: { replicas: 1, partitions: 4 }
-      events: { replicas: 1, partitions: 4 }
+By default, the creation of the kafka topics assume multiple kafka servers. If there is only one, then
+kafka_replicas should be set to 1. The default is 3.
+
+The number of partitions for the kafka topics can be controlled with:
+- kafka_events_partitions - number of partitions for the various events topics, the default is 12
+- kafka_metrics_partitions - number of partitions for the metrics topic, the default is 3
+- kafka_retry_notifications_partitions - This should be the number of systems running the Notification Engine, the default is 3
+
+If the kafka topics have been created, neither the number of partitions nor the number of replicas will not be
+changed even if the above parameters are changed and the role run again.
 
 ## TODO
 - The notification engine user could be given readonly access to the db but in the current setup there is no way

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ kafka_replicas should be set to 1. The default is 3.
 
 The number of partitions for the kafka topics can be controlled with:
 - kafka_events_partitions - number of partitions for the various events topics, the default is 12
-- kafka_metrics_partitions - number of partitions for the metrics topic, the default is 3
+- kafka_metrics_partitions - number of partitions for the metrics topic, the default is 64
 - kafka_retry_notifications_partitions - This should be the number of systems running the Notification Engine, the default is 3
 
 If the kafka topics have been created, neither the number of partitions nor the number of replicas will not be

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,4 +16,17 @@ mysql_root_dir: /var/lib/mysql
 monasca_schema_file: "{{mysql_root_dir}}/mon.sql"
 winchester_schema_file: "{{mysql_root_dir}}/winchester.sql"
 
-kafka_topics: {}  # If this isn't specified as empty skipping it fails
+kafka_events_partitions: 12
+kafka_metrics_partitions: 64
+# This should be the number of systems running the Notification Engine
+kafka_retry_notifications_partitions: 3
+kafka_replicas: 3
+
+kafka_topics:
+  metrics: { replicas: "{{ kafka_replicas }}, partitions: {{ kafka_metrics_partitions }}" }
+  events: { replicas: "{{ kafka_replicas }}, partitions: {{ kafka_events_partitions }}" }
+  raw-events: { replicas: "{{ kafka_replicas }}, partitions: {{ kafka_events_partitions }}" }
+  transformed-events: { replicas: "{{ kafka_replicas }}, partitions: {{ kafka_events_partitions }}" }
+  alarm-state-transitions: { replicas: "{{ kafka_replicas }}, partitions: {{ kafka_events_partitions }}" }
+  alarm-notifications: { replicas: "{{ kafka_replicas }}, partitions: {{ kafka_events_partitions }}" }
+  retry-notifications: { replicas: "{{ kafka_replicas }}, partitions: {{ kafka_retry_notifications_partitions }}" }

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,10 +23,10 @@ kafka_retry_notifications_partitions: 3
 kafka_replicas: 3
 
 kafka_topics:
-  metrics: { replicas: "{{ kafka_replicas }}, partitions: {{ kafka_metrics_partitions }}" }
-  events: { replicas: "{{ kafka_replicas }}, partitions: {{ kafka_events_partitions }}" }
-  raw-events: { replicas: "{{ kafka_replicas }}, partitions: {{ kafka_events_partitions }}" }
-  transformed-events: { replicas: "{{ kafka_replicas }}, partitions: {{ kafka_events_partitions }}" }
-  alarm-state-transitions: { replicas: "{{ kafka_replicas }}, partitions: {{ kafka_events_partitions }}" }
-  alarm-notifications: { replicas: "{{ kafka_replicas }}, partitions: {{ kafka_events_partitions }}" }
-  retry-notifications: { replicas: "{{ kafka_replicas }}, partitions: {{ kafka_retry_notifications_partitions }}" }
+  metrics: { replicas: "{{ kafka_replicas }}", partitions: "{{ kafka_metrics_partitions }}" }
+  events: { replicas: "{{ kafka_replicas }}", partitions: "{{ kafka_events_partitions }}" }
+  raw-events: { replicas: "{{ kafka_replicas }}", partitions: "{{ kafka_events_partitions }}" }
+  transformed-events: { replicas: "{{ kafka_replicas }}", partitions: "{{ kafka_events_partitions }}" }
+  alarm-state-transitions: { replicas: "{{ kafka_replicas }}", partitions: "{{ kafka_events_partitions }}" }
+  alarm-notifications: { replicas: "{{ kafka_replicas }}", partitions: "{{ kafka_events_partitions }}" }
+  retry-notifications: { replicas: "{{ kafka_replicas }}", partitions: "{{ kafka_retry_notifications_partitions }}" }


### PR DESCRIPTION
of partitions can be overridden in playbooks using this role.

The default kafka replicas and number of partitions are set up for
a three node cluster