### PR TITLE
streams definition tables and kafka api topic

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,8 @@ kafka_topics:
   events: { replicas: "{{ kafka_replicas }}", partitions: "{{ kafka_events_partitions }}" }
   raw-events: { replicas: "{{ kafka_replicas }}", partitions: "{{ kafka_events_partitions }}" }
   transformed-events: { replicas: "{{ kafka_replicas }}", partitions: "{{ kafka_events_partitions }}" }
+  stream-definitions: { replicas: "{{ kafka_replicas }}", partitions: "{{ kafka_events_partitions }}" }
+  transform-definitions: { replicas: "{{ kafka_replicas }}", partitions: "{{ kafka_events_partitions }}" }
   alarm-state-transitions: { replicas: "{{ kafka_replicas }}", partitions: "{{ kafka_events_partitions }}" }
   alarm-notifications: { replicas: "{{ kafka_replicas }}", partitions: "{{ kafka_events_partitions }}" }
   retry-notifications: { replicas: "{{ kafka_replicas }}", partitions: "{{ kafka_retry_notifications_partitions }}" }

--- a/templates/mon.sql.j2
+++ b/templates/mon.sql.j2
@@ -164,8 +164,6 @@ CREATE TABLE `stream_definition` (
   `group_by` mediumtext COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `fire_criteria` mediumtext COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `expiration` int(10) UNSIGNED DEFAULT '0',
-  `fire_pipeline` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT '',
-  `expire_pipeline` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT '',
   `actions_enabled` tinyint(1) NOT NULL DEFAULT '1',
   `created_at` datetime NOT NULL,
   `updated_at` datetime NOT NULL,

--- a/templates/mon.sql.j2
+++ b/templates/mon.sql.j2
@@ -141,6 +141,44 @@ CREATE TABLE `schema_migrations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 /*
+ * The tables needed by Monasca for event stream definitions
+ */
+CREATE TABLE `stream_actions` (
+  `stream_definition_id` varchar(36) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `action_id` varchar(36) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `action_type` enum('FIRE','EXPIRE') COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`stream_definition_id`,`action_id`,`action_type`),
+  KEY `stream_definition_id` (`stream_definition_id`),
+  KEY `action_type` (`action_type`),
+  KEY `fk_stream_action_notification_method_id` (`action_id`),
+  CONSTRAINT `fk_stream_action_stream_definition_id` FOREIGN KEY (`stream_definition_id`) REFERENCES `stream_definition` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_stream_action_notification_method_id` FOREIGN KEY (`action_id`) REFERENCES `notification_method` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `stream_definition` (
+  `id` varchar(36) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `tenant_id` varchar(36) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `description` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `select_by` mediumtext COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `group_by` mediumtext COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `fire_criteria` mediumtext COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `expiration` int(10) UNSIGNED DEFAULT '0',
+  `fire_pipeline` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT '',
+  `expire_pipeline` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT '',
+  `actions_enabled` tinyint(1) NOT NULL DEFAULT '1',
+  `created_at` datetime NOT NULL,
+  `updated_at` datetime NOT NULL,
+  `deleted_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `name` (`name`),
+  KEY `tenant_id` (`tenant_id`),
+  KEY `deleted_at` (`deleted_at`),
+  KEY `created_at` (`created_at`),
+  KEY `updated_at` (`updated_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+/*
  * To require ssl connections add 'REQUIRE SSL' to the end of all grant statements
  */
 {% for name, pass in mysql_users.iteritems() %}

--- a/templates/mon.sql.j2
+++ b/templates/mon.sql.j2
@@ -158,7 +158,7 @@ CREATE TABLE `stream_actions` (
 CREATE TABLE `stream_definition` (
   `id` varchar(36) COLLATE utf8mb4_unicode_ci NOT NULL,
   `tenant_id` varchar(36) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
+  `name` varchar(190) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `description` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `select_by` mediumtext COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `group_by` mediumtext COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -169,6 +169,7 @@ CREATE TABLE `stream_definition` (
   `updated_at` datetime NOT NULL,
   `deleted_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
+  UNIQUE KEY `tenant_name` (`tenant_id`,`name`),
   KEY `name` (`name`),
   KEY `tenant_id` (`tenant_id`),
   KEY `deleted_at` (`deleted_at`),


### PR DESCRIPTION
Put the streams definition tables in mon database, since this
contains configuration type data used by our API and processing engine.
The winchester database will contain
the distilled events, and this schema is defined by Rackspace.