### PR TITLE
Remove primary key on definition_dimensions_id

### DIFF
--- a/files/mon_metrics_schema.sql
+++ b/files/mon_metrics_schema.sql
@@ -6,8 +6,7 @@ CREATE TABLE MonMetrics.Measurements (
     definition_dimensions_id BINARY(20) NOT NULL,
     time_stamp TIMESTAMP NOT NULL,
     value FLOAT NOT NULL,
-    value_meta VARCHAR(2048),
-    PRIMARY KEY(definition_dimensions_id)
+    value_meta VARCHAR(2048)
 ) PARTITION BY EXTRACT('year' FROM time_stamp)*10000 + EXTRACT('month' FROM time_stamp)*100 + EXTRACT('day' FROM time_stamp);
 
 CREATE TABLE MonMetrics.Definitions(


### PR DESCRIPTION
definition_dimensions_id is not a primary key and duplicates
are expected. Vertica doesn't analyze constraints on insert,
but when queries are done, constraints are analyzed and the
query will fail if violated.