### PR TITLE
Fix mode arguments to be octal not decimal numbers

### DIFF
--- a/tasks/database_root.yml
+++ b/tasks/database_root.yml
@@ -1,4 +1,4 @@
 ---
 - name: Create database root dir
-  file: path={{ database_root_dir }} state=directory mode=755 recurse=yes
+  file: path={{ database_root_dir }} state=directory mode=0755 recurse=yes
   when: mysql_schema_enabled or winchester_schema_enabled or postgres_schema_enabled or (migration_pack | length > 0)

--- a/tasks/influxdb.yml
+++ b/tasks/influxdb.yml
@@ -4,7 +4,7 @@
 # parsing I could never get it to escape the json correctly
 
 - name: Write out the influxdb setup script
-  template: dest=/opt/influxdb/influxdb_setup.py owner=root group=root mode=750 src=influxdb_setup.py.j2
+  template: dest=/opt/influxdb/influxdb_setup.py owner=root group=root mode=0750 src=influxdb_setup.py.j2
 
 - name: Run the influxdb setup script
   command: /opt/influxdb/influxdb_setup.py

--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -2,7 +2,7 @@
 # ©Copyright 2015 Hewlett-Packard Development Company, L.P.
 
 - name: Copy mysql schema to host
-  template: dest={{monasca_schema_file}} owner=root group=root mode=640 src=mon_mysql.sql.j2
+  template: dest={{monasca_schema_file}} owner=root group=root mode=0640 src=mon_mysql.sql.j2
   register: copy_result
 
 - name: Apply mysql schema to db

--- a/tasks/postgres.yml
+++ b/tasks/postgres.yml
@@ -5,7 +5,7 @@
                  encoding="{{ postgres_encoding }}"
 
 - name: Copy postgres schema to host
-  template: dest={{monasca_schema_file}} owner=postgres group=postgres mode=640 src=mon_postgres.sql.j2
+  template: dest={{monasca_schema_file}} owner=postgres group=postgres mode=0640 src=mon_postgres.sql.j2
   register: copy_result
 
 - name: Apply postgres schema to db

--- a/tasks/vertica.yml
+++ b/tasks/vertica.yml
@@ -19,14 +19,14 @@
   when: create_database|failed
 
 - name: Copy over vertica sql files
-  copy: src={{ item }} dest=/var/vertica/{{ item }} mode=660
+  copy: src={{ item }} dest=/var/vertica/{{ item }} mode=0660
   with_items:
     - mon_alarms_schema.sql
     - mon_metrics_schema.sql
   register: sql_file_status
 
 - name: Copy over template vertica sql files
-  template: src={{ item }}.j2 dest=/var/vertica/{{ item }} mode=660
+  template: src={{ item }}.j2 dest=/var/vertica/{{ item }} mode=0660
   with_items:
     - mon_users_and_limits.sql
   register: sql_template_status
@@ -40,6 +40,6 @@
   when: sql_file_status|changed or sql_template_status|changed
 
 - name: Create cron job to clean up old partitions
-  template: src=vertica-cleanup.j2 dest=/etc/cron.daily/vertica-cleanup mode=750
+  template: src=vertica-cleanup.j2 dest=/etc/cron.daily/vertica-cleanup mode=0750
 
 # TODO: ENABLE SSL

--- a/tasks/winchester.yml
+++ b/tasks/winchester.yml
@@ -2,7 +2,7 @@
 # ©Copyright 2015 Hewlett-Packard Development Company, L.P.
 
 - name: Copy winchester schema to host
-  template: dest={{winchester_schema_file}} owner=root group=root mode=640 src=winchester.sql.j2
+  template: dest={{winchester_schema_file}} owner=root group=root mode=0640 src=winchester.sql.j2
   register: copy_result
 
 - name: Apply winchester schema to mysql db


### PR DESCRIPTION
From the ansible documentation:
"For those used to /usr/bin/chmod remember that modes are
actually octal numbers (like 0644). Leaving off the leading
zero will likely have unexpected results."